### PR TITLE
Prevent user from editing a subject of an existing note

### DIFF
--- a/src/domain/note.js
+++ b/src/domain/note.js
@@ -21,7 +21,9 @@ class Note {
     }
 
     update(note) {
-        return this._note.update(note);
+        let newNote = {};
+        newNote.body = note.body;
+        return this._note.update(newNote);
     }
 
     delete() {

--- a/test/domain/note.test.js
+++ b/test/domain/note.test.js
@@ -61,6 +61,22 @@ describe('Tests for domain Note', function() {
             });
         });
 
+        describe('updateOnlyBody', () => {
+            it('should only update the body of the note', () => {
+                return domainNote.update({
+                    subject: 'new subject',
+                    body: 'new body'
+                }).then(() => {
+                    domainNote.expose().should.match({
+                        id: noteId,
+                        subject: 'some subject',
+                        body: 'new body',
+                        updatedAt: _.isDate,
+                    });
+                });
+            });
+        });
+
         describe('delete', () => {
             it('should delete the note', () => {
                 return domainNote.delete().then(() => {


### PR DESCRIPTION
**Description**
When a user tries to edit the existing note, the web app only allows user to modify a body of the note, preventing a subject from being changed. However, there is a bug that enables user to modify a subject of the existing note. We can reproduce this bug by making a PUT request containing ‘subject’ attribute.

**How to reproduce this bug**
1. Open the web and select the note to edit
    Let's say subject is "test subject" and body is "test body". 
2. Open dev tools -> select tab network -> Selecting any item from the list will open new panel that has Headers, Preview, Response, and Timing tab.
3. Select Headers tab and find 'cookies'. Copy the content.
4. Open Postman and enter as follows
Paste cookie under Header>Cookie
Type the Json body under Body
{
	"subject": "fake subject",
	"body": "body changed"
}

and hit the PUT Send button. 

Even though the Json body contains ‘subject’ in the request, application should not allow it to be changed. Therefore, we are expecting the edited note to be..
{
	"subject": "test subject",
	"body": "body changed"
}

However, we get
{
	"subject": "fake subject",
	"body": "body changed"
}
We can see that both title and body is modified.

**Unit tests that fails with this bug**
-Please refer to the changes for detail test
This unit test will test if only the body of the existing note is modified when one tries to change both subject and body.
This test failed with this bug and passed after fixing the bug.

**Descriptions about what other problems this bug might cause**
Like a subject field, if we have other fields that should not be editable, one can modify these fields by sending a PUT request.

**Your thoughts about fundamental problems in the code structure that allows this kind of bugs exist**
The back-end code where the note is updated passes the whole object as a parameter, assuming that the only attribute in the request body is ‘body’. If a user tries to edit the note through UI, this code has no problem since there would be only ‘body’ in the request. Because back-end code does not check if the request contains fields other than ‘body’, it becomes possible to send a PUT request containing ‘subject’, say through Postman. This bug shows that passing the whole request body can change fields that is not supposed to. What we can do is to create an object that only contains ‘body’ and pass it to update the existing note so that it does not accidentally change other fields. 


**Two propositions to fix this bug, discussions about the pros and cons of each proposition, and reasons why you choose one of them**

1. Fix code on src/domain/note.js (the one that I chose)
As mentioned above, passing a whole request body when updating the entry can change other fields than ‘body’. Therefore, passing an object that only contains 'body' attribute will prevent user to change the subject. Even if someone sends PUT request containing subject attribute, it will only update the body of the existing note. I chose this method assuming that we still want to modify body text when PUT request contains both subject and body. This method is also easier to implement than the method suggested in #3; however, if we have a lot of fields to update or if fields are added/removed often, this method would not be the best solution since we need to add code to specify the fields to be updated.

2. Fix code on src/API/route/note.js
Almost exactly same as method 1 where we specify the fields to be updated. We can pass the object containing only body attribute when calling update function.
Since src/API/route/note.js should only contain the routing logic, I would not fix the code here.

3. Fix code on Note Model
Another method that we can use is to make changes on the Model. We can make ‘subject’ field be read-only by adding a hook such as beforeupdate or by simply using plugins such as “node-sequelize-noupdate-attributes”. Before updating the entry, it will check if PUT request is attempting to modify read-only field; if so, it will throw an error. I think this method is also doable but I chose first method because I still wanted to update the body rather than throwing an error. As discussed on method #1, if there are a lot of fields to update, this method could be a better solution. 





