### PR TITLE
New Feature: Store all versions of each note

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -1,0 +1,8 @@
+.hr {
+  margin-top: 5px;
+  margin-bottom: 5px;
+}
+
+.verBtn {
+  text-transform: none !important;
+}

--- a/public/src/app.js
+++ b/public/src/app.js
@@ -3,4 +3,7 @@
 angular.module('app', [
     'ngResource',
     'ngRoute',
+    'ngMaterial',
+    'ngMessages'
+
 ]);

--- a/public/src/appController.js
+++ b/public/src/appController.js
@@ -1,6 +1,6 @@
 'use strict';
 
-angular.module('app').controller('appController', function($rootScope, $location) {
+angular.module('app').controller('appController', function($rootScope, $location, $mdDialog) {
     $rootScope.$on('$routeChangeError', (event, current, previous, rejection) => {
         const status = _.get(rejection, 'status');
         const code = _.get(rejection, 'data.code');

--- a/public/src/note/create.js
+++ b/public/src/note/create.js
@@ -12,7 +12,7 @@ angular.module('app').component('noteCreate', {
             if (!this.error) {
                 Note.save({
                     subject: this.subject,
-                    body: this.body,
+                    body: [this.body]
                 }).$promise.then(() => {
                     $location.path('/');
                 }).catch(reason => {

--- a/public/src/note/detail.html
+++ b/public/src/note/detail.html
@@ -13,8 +13,18 @@
     <div class="panel-heading">
         <h3 class="panel-title" ng-bind="$ctrl.note.subject"></h3>
     </div>
-
-    <div class="panel-body" style="white-space: pre-wrap;" ng-bind="$ctrl.note.body"></div>
+    <div class="panel-body" style="white-space: pre-wrap;" ng-bind="$ctrl.note.body[$ctrl.note.body.length-1]"></div>
 
     <div class="panel-footer" ng-bind="$ctrl.note.updatedAt | date:'medium'"></div>
 </div>
+<h5> <center>Previous Versions</center></h5>
+<hr class="hr">
+<ul class="list-unstyled">
+  <section layout="row" layout-sm="column" layout-align="center center" layout-wrap="">
+    <li ng-repeat="item in $ctrl.note.body | orderBy:'$index':true" ng-hide="$first">
+      <md-button class="verBtn" ng-click="$ctrl.showAlert($event, $ctrl.note.body.length-$index, item)"   >
+            Version {{$ctrl.note.body.length-$index}}
+      </md-button>
+    </li>
+    </section>
+</ul>

--- a/public/src/note/detail.js
+++ b/public/src/note/detail.js
@@ -1,9 +1,27 @@
 'use strict';
-
 angular.module('app').component('noteDetail', {
     templateUrl: '/src/note/detail.html',
     bindings: {
         session: '<',
         note: '<',
     },
+    controller: function($mdDialog) {
+      this.showAlert = function(ev, version, body) {
+          // Appending dialog to document.body to cover sidenav in docs app
+          // Modal dialogs should fully cover application
+          // to prevent interaction outside of dialog
+          $mdDialog.show(
+            $mdDialog.alert()
+              .parent(angular.element(document.querySelector('#popupContainer')))
+              .clickOutsideToClose(true)
+              .title('Version ' + version)
+              .textContent(body)
+              .ariaLabel('Alert Dialog Demo')
+              .ok('Close')
+              .targetEvent(ev)
+          );
+        };
+
+    }
+
 });

--- a/public/src/note/edit.html
+++ b/public/src/note/edit.html
@@ -8,16 +8,13 @@
 
 <form>
     <div class="alert alert-danger" ng-if="$ctrl.error" ng-bind="$ctrl.error"></div>
-
     <div class="panel panel-default">
         <div class="panel-heading">
             <h3 class="panel-title" ng-bind="$ctrl.note.subject"></h3>
         </div>
-
         <div class="panel-body">
-            <textarea class="form-control" rows="10" ng-model="$ctrl.note.body"></textarea>
+            <textarea class="form-control" rows="10" ng-model="$ctrl.note.body" ng-init='$ctrl.note.body=$ctrl.note.body[$ctrl.note.body.length-1]'></textarea>
         </div>
-
         <div class="panel-footer" ng-bind="$ctrl.note.updatedAt | date:'medium'"></div>
     </div>
 
@@ -31,5 +28,3 @@
         </button>
     </div>
 </form>
-
-

--- a/src/app/views/index.html
+++ b/src/app/views/index.html
@@ -3,7 +3,7 @@
     <head>
         <title>Notes</title>
         <link rel="stylesheet" href="/lib/bootstrap/css/bootstrap.css">
-        <link rel="stylesheet" href="/lib/css/style.css">
+        <link rel="stylesheet" href="/css/style.css">
         <link rel="stylesheet" href="https://ajax.googleapis.com/ajax/libs/angular_material/1.1.12/angular-material.min.css">
         <link rel="shortcut icon" href="/favicon.ico">
     </head>

--- a/src/app/views/index.html
+++ b/src/app/views/index.html
@@ -2,9 +2,9 @@
 <html>
     <head>
         <title>Notes</title>
-
         <link rel="stylesheet" href="/lib/bootstrap/css/bootstrap.css">
-
+        <link rel="stylesheet" href="/lib/css/style.css">
+        <link rel="stylesheet" href="https://ajax.googleapis.com/ajax/libs/angular_material/1.1.12/angular-material.min.css">
         <link rel="shortcut icon" href="/favicon.ico">
     </head>
 
@@ -12,6 +12,14 @@
         <div class="content">
             <div class="container" ng-view></div>
         </div>
+        <!-- Angular Material requires Angular.js Libraries -->
+        <script src="https://ajax.googleapis.com/ajax/libs/angularjs/1.7.6/angular.min.js"></script>
+        <script src="https://ajax.googleapis.com/ajax/libs/angularjs/1.7.6/angular-animate.min.js"></script>
+        <script src="https://ajax.googleapis.com/ajax/libs/angularjs/1.7.6/angular-aria.min.js"></script>
+        <script src="https://ajax.googleapis.com/ajax/libs/angularjs/1.7.6/angular-messages.min.js"></script>
+
+        <!-- Angular Material Library -->
+        <script src="https://ajax.googleapis.com/ajax/libs/angular_material/1.1.12/angular-material.min.js"></script>
 
         <script type="text/javascript" src="/lib/lodash/lodash.js"></script>
         <script type="text/javascript" src="/lib/angular/angular.js"></script>

--- a/src/domain/note.js
+++ b/src/domain/note.js
@@ -21,7 +21,11 @@ class Note {
     }
 
     update(note) {
-        return this._note.update(note);
+        let oldBody = this._note.body;
+        let newNote = {};
+        oldBody.push(note.body);
+        newNote.body = oldBody
+        return this._note.update(newNote);
     }
 
     delete() {

--- a/src/model/note.js
+++ b/src/model/note.js
@@ -18,7 +18,7 @@ module.exports.define = sequelize => {
             }
         },
         body: {
-            type: Sequelize.TEXT,
+            type: Sequelize.ARRAY(Sequelize.TEXT),
             allowNull: false,
             validate: {
                 notEmpty: true

--- a/test/domain/note.test.js
+++ b/test/domain/note.test.js
@@ -19,7 +19,7 @@ describe('Tests for domain Note', function() {
 
                 return user.createNote({
                     subject: 'some subject',
-                    body: 'some body',
+                    body: ['some body'],
                 }).then(note => {
                     noteId = note.id;
                     domainNote = new domain.Note(note);
@@ -40,7 +40,7 @@ describe('Tests for domain Note', function() {
                 domainNote.expose().should.match({
                     id: noteId,
                     subject: 'some subject',
-                    body: 'some body',
+                    body: ['some body'],
                     updatedAt: _.isDate,
                 });
             });
@@ -54,7 +54,7 @@ describe('Tests for domain Note', function() {
                     domainNote.expose().should.match({
                         id: noteId,
                         subject: 'some subject',
-                        body: 'new body',
+                        body: ['some body', 'new body'],
                         updatedAt: _.isDate,
                     });
                 });

--- a/test/domain/user.test.js
+++ b/test/domain/user.test.js
@@ -21,7 +21,7 @@ describe('Tests for domain User', function() {
 
                     return q.all(_.map(_.times(5, n => ({
                         subject: `subject ${ n }`,
-                        body: `body ${ n }`,
+                        body: [`body ${ n }`],
                     })), note => {
                         return user.createNote(note);
                     })).then(notes => {
@@ -134,7 +134,7 @@ describe('Tests for domain User', function() {
             it('should create a new note associated to the user', () => {
                 return domainUser1.createNote({
                     subject: 'new subject',
-                    body: 'new body'
+                    body: ['new body']
                 }).then(createdNote => {
                     return domainUser1.note(createdNote.id).should.be.fulfilled();
                 });


### PR DESCRIPTION
**Description**
This feature will allow to store all versions of the note.

For example, when a user creates a new note, it is considered as version 1 and it works the same as before. When a user edits the body of the note, the latest note is now version 2. 

When a user clicks a note from the list, user will see a list of previous versions of that note such as 'Version1', 'Version2'..etc at the bottom. Clicking the version will show the body of the note in the modal window. I chose to use modal window rather than routing to other pages because I think it is easier for user to navigate and user will always edit the latest version of the note anyways. 


**Code**
To store all versions of the note, the data type of the body in the Note model is changed from Text to Array of Text. Every time the note is edited, new body will be pushed to the array, meaning that the last element in the array is the latest. Using this property, I could display the latest version when note is clicked/when user tries to edit the note.


**Unit tests**
Please refer to the commit for detail unit tests.
Basically, changes are made on creating and editing a note.
When note is created with body='some body', the result should be ['some body'] because the datatype in the model is changed to array. Likewise, when note is edited with 'new body', the result should match with ['some body', 'new body'] as the new content should be inserted to the array.